### PR TITLE
Add reason as a property of the event as opposed to a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ It contains the reason as associated data, which can be one of:
 Example:
 
     document.addEventListener('audioroute-changed',
-                              function(reason) {
-                                  console.log('Audio route changed: ' + reason);
+                              function(event) {
+                                  console.log('Audio route changed: ' + event.reason);
                               });
 
 

--- a/www/audioroute.js
+++ b/www/audioroute.js
@@ -15,7 +15,7 @@ AudioRoute.prototype.overrideOutput = function(output, successCallback, errorCal
 };
 
 function routeChangeCallback(reason) {
-    cordova.fireDocumentEvent('audioroute-changed', reason);
+    cordova.fireDocumentEvent('audioroute-changed', {reason: reason});
 }
 
 


### PR DESCRIPTION
Sending the string `reason` straight to cordova's `fireDocumentEvent` function munges the string into the event as if the string were actually an Array, so you end up with the event object containing `0, 1, 2, 3, ...` equal to the individual characters of the reason string. This makes it impossible to reliably extract the reason.

The example given also doesn't work as , `console.log("Audio route changed " + reason)` would yield `Audio route changed [object Event]`.

This PR fixes that by sending the reason as an object, which then gets merged properly into the event.
