### PR TITLE
Add ducking capabilities

### DIFF
--- a/src/ios/AudioRoute.m
+++ b/src/ios/AudioRoute.m
@@ -126,7 +126,7 @@ NSString *const kRouteConfigurationChange   = @"route-config-change";
 
     // make sure the AVAudioSession is properly configured
     [session setActive: YES error: nil];
-    [session setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
+    [session setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionDuckOthers error:nil];
 
     if (output != nil) {
         if ([output isEqualToString:@"speaker"]) {


### PR DESCRIPTION
Allow ducking to audio session after toggling. For example I use it to add DMTF feedback to logic. Without this additional code the os will reset the audio route to default earpiece when I play the sound.